### PR TITLE
feat: 为个人主页接入 Google Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter_Tight } from "next/font/google";
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import "./globals.css";
 import { profile } from "@/lib/data";
 
@@ -36,7 +37,10 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        <GoogleAnalytics />
+      </body>
     </html>
   );
 }

--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -1,0 +1,22 @@
+import Script from "next/script";
+
+export const GA_MEASUREMENT_ID = "G-CE0CMN7KMN";
+
+export function GoogleAnalytics() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
## 变更

- 新增 GA4 Google tag 组件
- 在根布局中加载 `G-CE0CMN7KMN`
- 自动发送首页 `page_view`，保留 GA4 增强型衡量能力

## 原因

个人主页此前只有访客地图，没有长期可用的 Google Analytics 数据流，无法持续查看页面浏览与独立访客趋势。

## 验证

- `npm run build`：通过
- 静态导出包含唯一一处 `gtag('config', 'G-CE0CMN7KMN')`
- 本地生产构建实际加载 `gtag.js`
- 浏览器网络记录确认向 `google-analytics.com/g/collect` 发送 `page_view`

`npm run lint` 当前会进入 Next.js 首次 ESLint 配置交互，仓库尚未配置 ESLint；这不是本次改动引入的代码错误。
